### PR TITLE
55-override-date-time-input

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -46,3 +46,8 @@
 #capture-video {
   width: 100%;
 }
+
+input.datetime {
+  border-color: $greige-darkest;
+  background-color: $greige-lightest;
+}

--- a/app/inputs/date_time_input.rb
+++ b/app/inputs/date_time_input.rb
@@ -1,0 +1,8 @@
+class DateTimeInput < SimpleForm::Inputs::DateTimeInput
+  def input(wrapper_options)
+    wrapper_options[:class] = ["form-select"]
+    merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
+    
+    @builder.date_field(attribute_name, merged_input_options)
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,6 @@ class Event < ApplicationRecord
 
   validates :name, presence: true
   validates :start_time, presence: true
-  validates :end_time, presence: true
 
   def self.ransackable_attributes(auth_object = nil)
     ['name', 'start_time', 'end_time', 'location', 'event_type_id', 'team_id']

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,7 @@ class Event < ApplicationRecord
 
   validates :name, presence: true
   validates :start_time, presence: true
-  validates :start_time, presence: true
+  validates :end_time, presence: true
 
   def self.ransackable_attributes(auth_object = nil)
     ['name', 'start_time', 'end_time', 'location', 'event_type_id', 'team_id']
@@ -18,6 +18,8 @@ class Event < ApplicationRecord
 
   private
   def valid_times
-    errors.add(:end_time, 'Your event cannot end before it starts!') if end_time.before?(start_time)
+    if start_time? && end_time? then
+      errors.add(:end_time, 'cannot be before start time!') if end_time.before?(start_time)
+    end
   end
 end

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -18,7 +18,4 @@ REM echo SQLPKG DIRECTORY: %SQLPKG_INSTALL_DIR%
 REM call bundle exec sqlpkg install
 
 echo PREPARING DATABASE
-call rails db:migrate:primary
-call rails db:migrate:queue
-call rails db:migrate:cache
-call rails db:migrate:errors
+call rails db:migrate:primary db:migrate:queue db:migrate:cache db:migrate:errors


### PR DESCRIPTION
closes #55
Overrides the SimpleForms date time input to use native controls. Looks better on Firefox and Chrome.