### PR TITLE
fix scaffold generator for breadcrumbs

### DIFF
--- a/lib/templates/erb/scaffold/index.html.erb.tt
+++ b/lib/templates/erb/scaffold/index.html.erb.tt
@@ -1,4 +1,4 @@
-<%% breadcrumb :<%= singular_table_name %> %>
+<%% breadcrumb :<%= plural_table_name %> %>
 
 <%%= search_form_for @q, data: {"controller": "turbo_search", "turbo-frame": "results"} do |f| %>
 <div class="card">


### PR DESCRIPTION
Changes the breadcrumb from a singular name to a plural name in `index.html.erb`