### PR TITLE
bugfix - timezone

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,6 @@ class ApplicationController < ActionController::Base
   end
 
   def set_time_zone(&block)
-    Time.use_zone(Settings[:time_zone], &block)
+    Time.use_zone(Settings[:time_zone].presence || 'UTC', &block)
   end
 end

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -68,7 +68,7 @@ class Settings
 
     @settings = Hash.new
     add_setting(:title, :string, "Site Name", "GatherPack", nil, "The name of the site")
-    add_setting(:time_zone, :time_zone, "Time Zone", "", nil, "The default time zone")
+    add_setting(:time_zone, :time_zone, "Time Zone", "UTC", nil, "The default time zone")
     add_setting(:shirt_sizes, :string, "Shirt Sizes", "Youth S, Youth M, Youth L, S, M, L, XL, XXL, 3XL, 4XL", 'People', "Comma-separated list of valid shirt sizes")
     add_setting(:gender_options, :string, "Gender Options", "M, F, X", 'People', "Comma-separated list of valid gender options")
   end

--- a/app/views/relationships/new.html.erb
+++ b/app/views/relationships/new.html.erb
@@ -6,7 +6,7 @@
     <h1>New Relationship</h1>
   </div>
   <div class="card-body">
-    <%= f.input :start_node, as: :select, label: "What is #{@person.identifier_name} to the other person?", collection: policy_scope(RelationshipNode), label_method: :to_s, value_method: :to_id %>
+    <%= f.input :start_node, as: :select, label: "Who is #{@person.identifier_name} in relation to the other person?", collection: policy_scope(RelationshipNode), label_method: :to_s, value_method: :to_id %>
 
     <% if @relationship.relationship_type %>
       <div class="row">


### PR DESCRIPTION
There was an issue with starting up Gatherpack without any prior-set settings, where if there was no timezone detected it would just set itself to nil, which is a problem when actually setting the timezone in the application controller. Now it defaults to "UTC" and also safechecks to "UTC" if the value is "nil" anyway.