### PR TITLE
fix: person searching on `time_clock_punches` and `memberships`

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -5,7 +5,7 @@ class MembershipsController < InternalController
   # GET /memberships
   def index
     @q = policy_scope(Membership).where(team: @team).ransack(params[:q])
-    @memberships = @q.result(distinct: true).includes(:person).order('person.last_name': :asc, 'person.first_name': :asc).page(params[:page])
+    @memberships = @q.result(distinct: true).includes(:person).page(params[:page])
   end
 
   # POST /memberships

--- a/app/controllers/time_clock_periods_controller.rb
+++ b/app/controllers/time_clock_periods_controller.rb
@@ -11,7 +11,7 @@ class TimeClockPeriodsController < InternalController
   # GET /time_clock_periods/1
   def show
     @q = policy_scope(TimeClockPunch).where(time_clock_period: @time_clock_period).ransack(params[:q])
-    @time_clock_punches = @q.result(distinct: true).includes(:person).order(start_time: :desc, end_time: :desc, 'person.first_name': :asc, 'person.last_name': :asc).page(params[:page])
+    @time_clock_punches = @q.result(distinct: true).includes(:person).order(start_time: :desc, end_time: :desc).page(params[:page])
     @time_clock_punches.each do |punch|
       if policy(punch).edit?
         @has_editable_punches = true

--- a/app/controllers/time_clock_punches_controller.rb
+++ b/app/controllers/time_clock_punches_controller.rb
@@ -5,7 +5,7 @@ class TimeClockPunchesController < InternalController
   # GET /time_clock_punches
   def index
     @q = policy_scope(TimeClockPunch).ransack(params[:q])
-    @time_clock_punches = @q.result(distinct: true).includes(:person).order(start_time: :desc, end_time: :desc, 'person.first_name': :asc, 'person.last_name': :asc).page(params[:page])
+    @time_clock_punches = @q.result(distinct: true).includes(:person).order(start_time: :desc, end_time: :desc).page(params[:page])
     @time_clock_punches.each do |punch|
       if policy(punch).edit?
         @has_editable_punches = true

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -4,7 +4,7 @@ class Membership < ApplicationRecord
   belongs_to :team
 
   def self.ransackable_attributes(auth_object = nil)
-    [ 'manager' ]
+    [ 'manager', 'person.display_name' ]
   end
 
   def self.ransackable_associations(auth_object = nil)


### PR DESCRIPTION
closes #184 

It seems like ordering people by first and last name generates an invalid `postgresql` command, which is why searching for person doesn't work on `time_clock_punches` and `memberships`.

I've tried sorting on the view, but it seemed to produce the same result. 

I've disabled ordering by name for now until a better way is found.