### PR TITLE
Breadcrumb fixes

### DIFF
--- a/app/helpers/nav_helper.rb
+++ b/app/helpers/nav_helper.rb
@@ -1,25 +1,36 @@
 module NavHelper
-  def nav_link(link, path, icon, method: 'get')
+  def nav_link(link, path, icon, method: "get")
     data = {}
-    if method != 'get'
-      data['turbo-method'] = method
+    if method != "get"
+      data["turbo-method"] = method
     end
-    tag.div class: 'nav-item' do
-      if (path == '/' && request.path == '/') ||
-          (path != '/' && request.path.starts_with?(path)) || 
-          (path == '/calendar' && request.path.starts_with?("/events"))
-        link_to path, class: 'active', data: data do
-          icon_text(icon, link)
-        end
-      else
-        link_to path, data: data do
-          icon_text(icon, link)
-        end
+    tag.div class: "nav-item" do
+      link_to path, class: active_status(path), data: data do
+        icon_text(icon, link)
       end
     end
   end
 
   def nav_heading(label)
-    tag.h6 label, class: 'nav-item'
+    tag.h6 label, class: "nav-item"
+  end
+
+  private
+
+  def active_status(path)
+    "active" if (path == "/" && request.path == "/") ||
+                (path != "/" && request.path.starts_with?(path)) ||
+
+                (path == "/calendar" && request.path.starts_with?("/events")) ||
+                (path == "/time_clock_punches" && request.path.starts_with?("/time_clock")) ||
+                (path == "/ledgers" && request.path.starts_with?("/ledger")) ||
+
+                (path == "/setup" && request.path.starts_with?("/team_types")) ||
+                (path == "/setup" && request.path.starts_with?("/badge_types")) ||
+                (path == "/setup" && request.path.starts_with?("/event_types")) ||
+                (path == "/setup" && request.path.starts_with?("/relationship_types")) ||
+                (path == "/setup" && request.path.starts_with?("/checkin_fields")) ||
+                (path == "/setup" && request.path.starts_with?("/ledger_tags")) ||
+                (path == "/setup" && request.path.starts_with?("/gateways"))
   end
 end

--- a/app/views/announcements/new.html.erb
+++ b/app/views/announcements/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "announcement" %>
+<% breadcrumb @announcement %>
 
 <%= simple_form_for(@announcement) do |f| %>
 <div class="card">

--- a/app/views/badge_assignments/new.html.erb
+++ b/app/views/badge_assignments/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "badge_assignment" %>
+<% breadcrumb @badge_assignment %>
 
 <%= simple_form_for([@badge, @badge_assignment]) do |f| %>
   <div class="card">

--- a/app/views/badge_types/new.html.erb
+++ b/app/views/badge_types/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "badge type" %>
+<% breadcrumb @badge_type %>
 
 <%= simple_form_for(@badge_type) do |f| %>
 <div class="card">

--- a/app/views/badges/new.html.erb
+++ b/app/views/badges/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "badge" %>
+<% breadcrumb @badge %>
 
 <%= simple_form_for(@badge) do |f| %>
 <div class="card">

--- a/app/views/calendar/index.html.erb
+++ b/app/views/calendar/index.html.erb
@@ -59,7 +59,7 @@
             </div>
             <div class="modal-footer">
               <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-              <button type="button" class="btn btn-primary" id="calendar-settings-submit" data-bs-dismiss="modal">Save changes</button>
+              <button type="button" class="btn btn-primary" id="calendar-settings-submit" data-bs-dismiss="modal">Save Changes</button>
             </div>
           </div>
         </div>

--- a/app/views/calendar_notes/index.html.erb
+++ b/app/views/calendar_notes/index.html.erb
@@ -3,7 +3,7 @@
 <%= search_form_for @q, data: { "controller": "turbo_search", "turbo-frame": "results" } do |f| %>
 <div class="card">
   <div class="card-header">
-    <h1>Calendar notes</h1>
+    <h1>Calendar Notes</h1>
   </div>
   <div class="card-body">
     <div class="col">
@@ -11,7 +11,7 @@
     </div>
   </div>
   <div class="card-footer">
-    <%= link_to "New calendar note", new_calendar_note_path, class: 'btn btn-success' %>
+    <%= link_to "New Calendar Note", new_calendar_note_path, class: 'btn btn-success' %>
     <%= f.submit 'Search', class: 'btn btn-primary', data: { action: "turbo_search#search" } %>
     <%= link_to 'Clear Search', request.path, class: "btn btn-dark", data: { action: "turbo_search#clear" } %>
   </div>

--- a/app/views/calendar_notes/new.html.erb
+++ b/app/views/calendar_notes/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "Calendar Note" %>
+<% breadcrumb :new, "calendar note" %>
 
 <%= simple_form_for(@calendar_note) do |f| %>
   <div class="card">

--- a/app/views/calendar_notes/new.html.erb
+++ b/app/views/calendar_notes/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "calendar note" %>
+<% breadcrumb @calendar_note %>
 
 <%= simple_form_for(@calendar_note) do |f| %>
   <div class="card">

--- a/app/views/checkin_fields/index.html.erb
+++ b/app/views/checkin_fields/index.html.erb
@@ -8,9 +8,9 @@
   <div class="card-body">
   </div>
   <div class="card-footer">
-    <%= link_to "New checkin field", new_checkin_field_path, class: 'btn btn-success' %>
+    <%= link_to "New Checkin Field", new_checkin_field_path, class: 'btn btn-success' %>
     <%= f.submit 'Search', class: 'btn btn-primary', data: { action: "turbo_search#search" } %>
-    <%= link_to 'Clear search', request.path, class: "btn btn-dark", data: { action: "turbo_search#clear" } %>
+    <%= link_to 'Clear Search', request.path, class: "btn btn-dark", data: { action: "turbo_search#clear" } %>
   </div>
 </div>
 <% end %>

--- a/app/views/checkin_fields/index.html.erb
+++ b/app/views/checkin_fields/index.html.erb
@@ -3,7 +3,7 @@
 <%= search_form_for @q, data: {"controller": "turbo_search", "turbo-frame": "results"} do |f| %>
 <div class="card">
   <div class="card-header">
-    <h1>Checkin fields</h1>
+    <h1>Checkin Fields</h1>
   </div>
   <div class="card-body">
   </div>

--- a/app/views/checkin_fields/new.html.erb
+++ b/app/views/checkin_fields/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "checkin field" %>
+<% breadcrumb @checkin_field %>
 
 <%= simple_form_for(@checkin_field) do |f| %>
 <div class="card">

--- a/app/views/checkins/_checkins.html.erb
+++ b/app/views/checkins/_checkins.html.erb
@@ -1,7 +1,7 @@
 <%= search_form_for q, url: event_url, data: {"controller": "turbo_search", "turbo-frame": "results"} do |f| %>
 <div class="card">
   <div class="card-header">
-    <h3>Search people</h3>
+    <h3>Search People</h3>
   </div>
   <div class="card-body">
       <div class="col">
@@ -16,7 +16,7 @@
     <% end %>
 
     <%= f.submit 'Search', class: 'btn btn-primary', data: { action: "turbo_search#search" } %>
-    <%= link_to 'Clear search', request.path, class: "btn btn-dark", data: { action: "turbo_search#clear" } %>
+    <%= link_to 'Clear Search', request.path, class: "btn btn-dark", data: { action: "turbo_search#clear" } %>
   </div>
 </div>
 <% end %>

--- a/app/views/checkins/new.html.erb
+++ b/app/views/checkins/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "checkin" %>
+<% breadcrumb @checkin %>
 
 <%= simple_form_for @checkin, url: event_checkins_path do |f| %>
 <div class="card">

--- a/app/views/event_types/new.html.erb
+++ b/app/views/event_types/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "event type" %>
+<% breadcrumb @event_type %>
 
 <%= simple_form_for(@event_type) do |f| %>
 <div class="card">

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "event" %>
+<% breadcrumb @event %>
 
 <%= simple_form_for(@event) do |f| %>
 <div class="card">

--- a/app/views/gateways/new.html.erb
+++ b/app/views/gateways/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "gateway" %>
+<% breadcrumb @gateway %>
 
 <%= form_with(url: gateways_path, method: 'POST') do |f| %>
   <div class="card">

--- a/app/views/hooks/new.html.erb
+++ b/app/views/hooks/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "hook" %>
+<% breadcrumb @hook %>
 
 <%= simple_form_for(@hook) do |f| %>
 <div class="card">

--- a/app/views/ledger_entries/new.html.erb
+++ b/app/views/ledger_entries/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "ledger entry" %>
+<% breadcrumb @ledger_entry %>
 
 <%= simple_form_for([@ledger, @ledger_entry]) do |f| %>
   <div class="card">

--- a/app/views/ledger_entries/new.html.erb
+++ b/app/views/ledger_entries/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "ledger_entry" %>
+<% breadcrumb :new, "ledger entry" %>
 
 <%= simple_form_for([@ledger, @ledger_entry]) do |f| %>
   <div class="card">

--- a/app/views/ledger_entry_links/index.html.erb
+++ b/app/views/ledger_entry_links/index.html.erb
@@ -8,7 +8,7 @@
   <div class="card-body">
   </div>
   <div class="card-footer">
-    <%= link_to "New ledger entry link", new_ledger_entry_link_path, class: 'btn btn-success' %>
+    <%= link_to "New Ledger Entry Link", new_ledger_entry_link_path, class: 'btn btn-success' %>
     <%= f.submit 'Search', class: 'btn btn-primary', data: { action: "turbo_search#search" } %>
     <%= link_to 'Clear Search', request.path, class: "btn btn-dark", data: { action: "turbo_search#clear" } %>
   </div>

--- a/app/views/ledger_entry_links/new.html.erb
+++ b/app/views/ledger_entry_links/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "ledger entry link" %>
+<% breadcrumb @ledger_entry_link %>
 
 <%= simple_form_for(@ledger_entry_link) do |f| %>
 <div class="card">

--- a/app/views/ledger_entry_links/new.html.erb
+++ b/app/views/ledger_entry_links/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "ledger_entry_link" %>
+<% breadcrumb :new, "ledger entry link" %>
 
 <%= simple_form_for(@ledger_entry_link) do |f| %>
 <div class="card">

--- a/app/views/ledger_ownerships/index.html.erb
+++ b/app/views/ledger_ownerships/index.html.erb
@@ -8,7 +8,7 @@
   <div class="card-body">
   </div>
   <div class="card-footer">
-    <%= link_to "New ledger ownership", new_ledger_ownership_path, class: 'btn btn-success' %>
+    <%= link_to "New Ledger Ownership", new_ledger_ownership_path, class: 'btn btn-success' %>
     <%= f.submit 'Search', class: 'btn btn-primary', data: { action: "turbo_search#search" } %>
     <%= link_to 'Clear Search', request.path, class: "btn btn-dark", data: { action: "turbo_search#clear" } %>
   </div>

--- a/app/views/ledger_ownerships/new.html.erb
+++ b/app/views/ledger_ownerships/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "ledger ownership" %>
+<% breadcrumb @ledger_ownership %>
 
 <%= simple_form_for(@ledger_ownership) do |f| %>
   <div class="card">

--- a/app/views/ledger_ownerships/new.html.erb
+++ b/app/views/ledger_ownerships/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "ledger_ownership" %>
+<% breadcrumb :new, "ledger ownership" %>
 
 <%= simple_form_for(@ledger_ownership) do |f| %>
   <div class="card">

--- a/app/views/ledger_tags/index.html.erb
+++ b/app/views/ledger_tags/index.html.erb
@@ -3,7 +3,7 @@
 <%= search_form_for @q, data: { "controller": "turbo_search", "turbo-frame": "results" } do |f| %>
 <div class="card">
   <div class="card-header">
-    <h1>Ledger tags</h1>
+    <h1>Ledger Tags</h1>
   </div>
   <div class="card-body">
   </div>

--- a/app/views/ledger_tags/index.html.erb
+++ b/app/views/ledger_tags/index.html.erb
@@ -8,7 +8,7 @@
   <div class="card-body">
   </div>
   <div class="card-footer">
-    <%= link_to "New ledger tag", new_ledger_tag_path, class: 'btn btn-success' %>
+    <%= link_to "New Ledger Tag", new_ledger_tag_path, class: 'btn btn-success' %>
     <%= f.submit 'Search', class: 'btn btn-primary', data: { action: "turbo_search#search" } %>
     <%= link_to 'Clear Search', request.path, class: "btn btn-dark", data: { action: "turbo_search#clear" } %>
   </div>

--- a/app/views/ledger_tags/new.html.erb
+++ b/app/views/ledger_tags/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "ledger tag" %>
+<% breadcrumb @ledger_tag %>
 
 <%= simple_form_for(@ledger_tag) do |f| %>
   <div class="card">

--- a/app/views/ledger_tags/new.html.erb
+++ b/app/views/ledger_tags/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "ledger_tag" %>
+<% breadcrumb :new, "ledger tag" %>
 
 <%= simple_form_for(@ledger_tag) do |f| %>
   <div class="card">

--- a/app/views/ledger_transfers/new.html.erb
+++ b/app/views/ledger_transfers/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "ledger transfer" %>
+<% breadcrumb @ledger_transfer %>
 
 <%= simple_form_for(@ledger_transfer) do |f| %>
   <div class="card">

--- a/app/views/ledger_transfers/new.html.erb
+++ b/app/views/ledger_transfers/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "ledger_transfer" %>
+<% breadcrumb :new, "ledger transfer" %>
 
 <%= simple_form_for(@ledger_transfer) do |f| %>
   <div class="card">
@@ -9,7 +9,7 @@
       <%= render "form", f: f %>
     </div>
     <div class="card-footer">
-      <%= link_to "Cancel", ledger_transfers_path, class: 'btn btn-warning' %>
+      <%= link_to "Cancel", ledgers_path, class: 'btn btn-warning' %>
       <%= f.button :submit, class: 'btn btn-primary' %>
     </div>
   </div>

--- a/app/views/ledgers/index.html.erb
+++ b/app/views/ledgers/index.html.erb
@@ -8,7 +8,7 @@
   <div class="card-body">
   </div>
   <div class="card-footer">
-    <%= link_to "New ledger", new_ledger_path, class: 'btn btn-success' if policy(Ledger).new? %>
+    <%= link_to "New Ledger", new_ledger_path, class: 'btn btn-success' if policy(Ledger).new? %>
     <%= f.submit 'Search', class: 'btn btn-primary', data: { action: "turbo_search#search" } %>
     <%= link_to 'Clear Search', request.path, class: "btn btn-dark", data: { action: "turbo_search#clear" } %>
   </div>

--- a/app/views/ledgers/new.html.erb
+++ b/app/views/ledgers/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "ledger" %>
+<% breadcrumb @ledger %>
 
 <%= simple_form_for(@ledger) do |f| %>
   <div class="card">

--- a/app/views/mailbox_messages/new.html.erb
+++ b/app/views/mailbox_messages/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "mailbox_message" %>
+<% breadcrumb @mailbox_message %>
 
 <%= simple_form_for([@mailbox, @mailbox_message]) do |f| %>
 <div class="card">

--- a/app/views/mailboxes/new.html.erb
+++ b/app/views/mailboxes/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "mailbox" %>
+<% breadcrumb @mailbox %>
 
 <%= simple_form_for(@mailbox) do |f| %>
 <div class="card">

--- a/app/views/memberships/edit.html.erb
+++ b/app/views/memberships/edit.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb @team, @membership %>
+<% breadcrumb @membership %>
 
 <%= simple_form_for([@team, @membership]) do |f| %>
 <div class="card">

--- a/app/views/memberships/new.html.erb
+++ b/app/views/memberships/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "membership" %>
+<% breadcrumb @membership %>
 
 <%= simple_form_for([@team, @membership]) do |f| %>
   <div class="card">

--- a/app/views/memberships/show.html.erb
+++ b/app/views/memberships/show.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb @team, @membership %>
+<% breadcrumb @membership %>
 
 <div class="card">
   <div class="card-header">

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "page" %>
+<% breadcrumb @page %>
 
 <%= simple_form_for(@page) do |f| %>
 <div class="card">

--- a/app/views/people/new.html.erb
+++ b/app/views/people/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, 'person' %>
+<% breadcrumb @person %>
 
 <%= simple_form_for(@person) do |f| %>
 <div class="card">

--- a/app/views/relationship_types/index.html.erb
+++ b/app/views/relationship_types/index.html.erb
@@ -3,7 +3,7 @@
 <%= search_form_for @q, data: {"controller": "turbo_search", "turbo-frame": "results"} do |f| %>
 <div class="card">
   <div class="card-header">
-    <h1>Relationship types</h1>
+    <h1>Relationship Types</h1>
   </div>
   <div class="card-body">
   </div>

--- a/app/views/relationship_types/new.html.erb
+++ b/app/views/relationship_types/new.html.erb
@@ -1,9 +1,9 @@
-<% breadcrumb :new, "Relationship Type" %>
+<% breadcrumb :new, "relationship type" %>
 
 <%= simple_form_for(@relationship_type) do |f| %>
 <div class="card">
   <div class="card-header">
-    <h1>New Relationship Type</h1>
+    <h1>New relationship type</h1>
   </div>
   <div class="card-body">
     <%= render "form", f: f %>

--- a/app/views/relationship_types/new.html.erb
+++ b/app/views/relationship_types/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "relationship type" %>
+<% breadcrumb @relationship_type %>
 
 <%= simple_form_for(@relationship_type) do |f| %>
 <div class="card">

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "report" %>
+<% breadcrumb @report %>
 
 <%= simple_form_for(@report) do |f| %>
 <div class="card">

--- a/app/views/team_types/new.html.erb
+++ b/app/views/team_types/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "team type" %>
+<% breadcrumb @team_type %>
 
 <%= simple_form_for(@team_type) do |f| %>
 <div class="card">

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "team" %>
+<% breadcrumb @team %>
 
 <%= simple_form_for(@team) do |f| %>
 <div class="card">

--- a/app/views/time_clock_periods/new.html.erb
+++ b/app/views/time_clock_periods/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "time clock period" %>
+<% breadcrumb @time_clock_period %>
 
 <%= simple_form_for(@time_clock_period) do |f| %>
 <div class="card">

--- a/app/views/time_clock_periods/show.html.erb
+++ b/app/views/time_clock_periods/show.html.erb
@@ -42,7 +42,7 @@
     </div>
     <div class="card-footer">
       <%= f.submit 'Search', class: 'btn btn-primary', data: { action: "turbo_search#search" } %>
-      <%= link_to 'Clear search', request.path, class: "btn btn-dark", data: { action: "turbo_search#clear" } %>
+      <%= link_to 'Clear Search', request.path, class: "btn btn-dark", data: { action: "turbo_search#clear" } %>
     </div>
   </div>
 <% end %>

--- a/app/views/time_clock_punches/new.html.erb
+++ b/app/views/time_clock_punches/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "time clock punch" %>
+<% breadcrumb @time_clock_punch %>
 
 <%= simple_form_for(@time_clock_punch) do |f| %>
 <div class="card">

--- a/app/views/tokens/new.html.erb
+++ b/app/views/tokens/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "token" %>
+<% breadcrumb @token %>
 
 <%= simple_form_for(@token) do |f| %>
 <div class="card">

--- a/app/views/variables/new.html.erb
+++ b/app/views/variables/new.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :new, "variable" %>
+<% breadcrumb @variable %>
 
 <%= simple_form_for(@variable) do |f| %>
 <div class="card">

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,7 +1,3 @@
 crumb :root do
   link "Home", root_path
 end
-
-crumb :new do |type|
-  link "New #{type}"
-end

--- a/config/breadcrumbs/announcement.rb
+++ b/config/breadcrumbs/announcement.rb
@@ -3,6 +3,6 @@ crumb :announcements do
 end
 
 crumb :announcement do |announcement|
-  link announcement.identifier_name, announcement
+  link announcement.new_record? ? "New announcement" : announcement.identifier_name, announcement
   parent :announcements
 end

--- a/config/breadcrumbs/badge.rb
+++ b/config/breadcrumbs/badge.rb
@@ -3,6 +3,6 @@ crumb :badges do
 end
 
 crumb :badge do |badge|
-  link badge.identifier_name, badge
+  link badge.new_record? ? "New badge" : badge.identifier_name, badge
   parent :badges
 end

--- a/config/breadcrumbs/badge_assignment.rb
+++ b/config/breadcrumbs/badge_assignment.rb
@@ -4,6 +4,6 @@ crumb :badge_assignments do |badge|
 end
 
 crumb :badge_assignment do |badge_assignment|
-  link badge_assignment.identifier_name, badge_badge_assignment_path(badge_assignment.badge, badge_assignment)
-  parent :badge, badge_assignment.badge
+  link badge_assignment.new_record? ? "New badge assignment" : [ badge_assignment.identifier_name, badge_badge_assignment_path(badge_assignment.badge, badge_assignment) ]
+  parent :badge_assignments, badge_assignment.badge
 end

--- a/config/breadcrumbs/badge_type.rb
+++ b/config/breadcrumbs/badge_type.rb
@@ -1,5 +1,6 @@
 crumb :badge_types do
   link "Badge Types", badge_types_path
+  parent :setup
 end
 
 crumb :badge_type do |badge_type|

--- a/config/breadcrumbs/badge_type.rb
+++ b/config/breadcrumbs/badge_type.rb
@@ -4,6 +4,6 @@ crumb :badge_types do
 end
 
 crumb :badge_type do |badge_type|
-  link badge_type.identifier_name, badge_type
+  link badge_type.new_record? ? "New badge type" : badge_type.identifier_name, badge_type
   parent :badge_types
 end

--- a/config/breadcrumbs/calendar_note.rb
+++ b/config/breadcrumbs/calendar_note.rb
@@ -3,6 +3,6 @@ crumb :calendar_notes do
 end
 
 crumb :calendar_note do |calendar_note|
-  link calendar_note.identifier_name + if calendar_note.noteable then " - " + calendar_note.noteable.identifier_name else "" end, calendar_note
+  link calendar_note.new_record? ? "New calendar note" : calendar_note.identifier_name + if calendar_note.noteable then " - " + calendar_note.noteable.identifier_name else "" end, calendar_note
   parent :calendar
 end

--- a/config/breadcrumbs/checkin_field.rb
+++ b/config/breadcrumbs/checkin_field.rb
@@ -1,5 +1,6 @@
 crumb :checkin_fields do
   link "Checkin Fields", checkin_fields_path
+  parent :setup
 end
 
 crumb :checkin_field do |checkin_field|

--- a/config/breadcrumbs/checkin_field.rb
+++ b/config/breadcrumbs/checkin_field.rb
@@ -4,6 +4,6 @@ crumb :checkin_fields do
 end
 
 crumb :checkin_field do |checkin_field|
-  link checkin_field.identifier_name, checkin_field
+  link checkin_field.new_record? ? "New checkin field" : checkin_field.identifier_name, checkin_field
   parent :checkin_fields
 end

--- a/config/breadcrumbs/event_type.rb
+++ b/config/breadcrumbs/event_type.rb
@@ -4,6 +4,6 @@ crumb :event_types do
 end
 
 crumb :event_type do |event_type|
-  link event_type.identifier_name, event_type
+  link event_type.new_record? ? "New event type" : event_type.identifier_name, event_type
   parent :event_types
 end

--- a/config/breadcrumbs/event_type.rb
+++ b/config/breadcrumbs/event_type.rb
@@ -1,5 +1,6 @@
 crumb :event_types do
   link "Event Types", event_types_path
+  parent :setup
 end
 
 crumb :event_type do |event_type|

--- a/config/breadcrumbs/events.rb
+++ b/config/breadcrumbs/events.rb
@@ -3,12 +3,12 @@ crumb :events do
 end
 
 crumb :event do |event|
-  link event.identifier_name, event
+  link event.new_record? ? "New event" : event.identifier_name, event
   parent :calendar
 end
 
 crumb :checkin do |checkin|
-  link checkin.identifier_name
+  link checkin.new_record? ? "New checkin" : checkin.identifier_name
   parent :event, checkin.event
 end
 

--- a/config/breadcrumbs/gateway.rb
+++ b/config/breadcrumbs/gateway.rb
@@ -4,21 +4,21 @@ crumb :gateways do
 end
 
 crumb :gateway do |gateway|
-  link gateway.identifier_name, gateway
+  link gateway.new_record? ? "New gateway" : gateway.identifier_name, gateway
   parent :gateways
 end
 
 crumb :"gateway/stripe_gateway" do |gateway|
-  link gateway.identifier_name, gateway_path(gateway)
+  link gateway.new_record? ? "New gateway" : [ gateway.identifier_name, gateway_path(gateway) ]
   parent :gateways
 end
 
 crumb :"gateway/postmark_receiving_gateway" do |gateway|
-  link gateway.identifier_name, gateway_path(gateway)
+  link gateway.new_record? ? "New gateway" : [ gateway.identifier_name, gateway_path(gateway) ]
   parent :gateways
 end
 
 crumb :"gateway/postmark_sending_gateway" do |gateway|
-  link gateway.identifier_name, gateway_path(gateway)
+  link gateway.new_record? ? "New gateway" : [ gateway.identifier_name, gateway_path(gateway) ]
   parent :gateways
 end

--- a/config/breadcrumbs/gateway.rb
+++ b/config/breadcrumbs/gateway.rb
@@ -1,5 +1,6 @@
 crumb :gateways do
   link "Gateways", gateways_path
+  parent :setup
 end
 
 crumb :gateway do |gateway|

--- a/config/breadcrumbs/hook.rb
+++ b/config/breadcrumbs/hook.rb
@@ -3,6 +3,6 @@ crumb :hooks do
 end
 
 crumb :hook do |hook|
-  link hook.identifier_name, hook
+  link hook.new_record? ? "New hook" : hook.identifier_name, hook
   parent :hooks
 end

--- a/config/breadcrumbs/ledger.rb
+++ b/config/breadcrumbs/ledger.rb
@@ -3,6 +3,11 @@ crumb :ledgers do
 end
 
 crumb :ledger do |ledger|
-  link ledger.identifier_name, ledger
+  link ledger.new_record? ? "New ledger" : ledger.identifier_name, ledger
+  parent :ledgers
+end
+
+crumb :ledger_transfer do
+  link "New ledger transfer"
   parent :ledgers
 end

--- a/config/breadcrumbs/ledger_entry.rb
+++ b/config/breadcrumbs/ledger_entry.rb
@@ -1,4 +1,4 @@
 crumb :ledger_entry do |ledger_entry|
-  link ledger_entry.identifier_name, ledger_ledger_entry_path(ledger_entry.ledger, ledger_entry)
+  link ledger_entry.new_record? ? "New ledger entry" : [ ledger_entry.identifier_name, ledger_ledger_entry_path(ledger_entry.ledger, ledger_entry) ]
   parent :ledger, ledger_entry.ledger
 end

--- a/config/breadcrumbs/ledger_entry_link.rb
+++ b/config/breadcrumbs/ledger_entry_link.rb
@@ -3,6 +3,6 @@ crumb :ledger_entry_links do
 end
 
 crumb :ledger_entry_link do |ledger_entry_link|
-  link ledger_entry_link.identifier_name, ledger_entry_link
+  link ledger_entry_link.new_record? ? "New ledger entry link" : ledger_entry_link.identifier_name, ledger_entry_link
   parent :ledger_entry_links
 end

--- a/config/breadcrumbs/ledger_entry_link.rb
+++ b/config/breadcrumbs/ledger_entry_link.rb
@@ -1,5 +1,5 @@
 crumb :ledger_entry_links do
-  link "Ledger_entry_links", ledger_entry_links_path
+  link "Ledger Entry Links", ledger_entry_links_path
 end
 
 crumb :ledger_entry_link do |ledger_entry_link|

--- a/config/breadcrumbs/ledger_ownership.rb
+++ b/config/breadcrumbs/ledger_ownership.rb
@@ -4,6 +4,6 @@ crumb :ledger_ownerships do |ledger|
 end
 
 crumb :ledger_ownership do |ledger_ownership|
-  link ledger_ownership.identifier_name, ledger_ownership_path(ledger_ownership.ledger, ledger_ownership)
+  link ledger_ownership.new_record? ? "New ledger ownership" : ledger_ownership.identifier_name
   parent :ledger_ownerships, ledger_ownership.ledger
 end

--- a/config/breadcrumbs/ledger_tag.rb
+++ b/config/breadcrumbs/ledger_tag.rb
@@ -1,5 +1,5 @@
 crumb :ledger_tags do
-  link "Ledger_tags", ledger_tags_path
+  link "Ledger Tags", ledger_tags_path
 end
 
 crumb :ledger_tag do |ledger_tag|

--- a/config/breadcrumbs/ledger_tag.rb
+++ b/config/breadcrumbs/ledger_tag.rb
@@ -1,5 +1,6 @@
 crumb :ledger_tags do
   link "Ledger Tags", ledger_tags_path
+  parent :setup
 end
 
 crumb :ledger_tag do |ledger_tag|

--- a/config/breadcrumbs/ledger_tag.rb
+++ b/config/breadcrumbs/ledger_tag.rb
@@ -4,6 +4,6 @@ crumb :ledger_tags do
 end
 
 crumb :ledger_tag do |ledger_tag|
-  link ledger_tag.identifier_name, ledger_tag
+  link ledger_tag.new_record? ? "New ledger tag" : ledger_tag.identifier_name, ledger_tag
   parent :ledger_tags
 end

--- a/config/breadcrumbs/mailbox.rb
+++ b/config/breadcrumbs/mailbox.rb
@@ -3,6 +3,6 @@ crumb :mailboxes do
 end
 
 crumb :mailbox do |mailbox|
-  link mailbox.identifier_name, mailbox
+  link mailbox.new_record? ? "New mailbox" : mailbox.identifier_name, mailbox
   parent :mailboxes
 end

--- a/config/breadcrumbs/mailbox_message.rb
+++ b/config/breadcrumbs/mailbox_message.rb
@@ -1,4 +1,4 @@
 crumb :mailbox_message do |mailbox_message|
-  link mailbox_message.identifier_name, mailbox_mailbox_message_path(mailbox_message.mailbox, mailbox_message)
+  link mailbox_message.new_record? ? "New mailbox message" : [ mailbox_message.identifier_name, mailbox_mailbox_message_path(mailbox_message.mailbox, mailbox_message) ]
   parent :mailbox, mailbox_message.mailbox
 end

--- a/config/breadcrumbs/membership.rb
+++ b/config/breadcrumbs/membership.rb
@@ -2,3 +2,8 @@ crumb :memberships do |team|
   link "Memberships", team_memberships_path(team)
   parent :team, team
 end
+
+crumb :membership do |membership|
+  link membership.new_record? ? "New membership" : membership.identifier_name
+  parent :memberships, membership.team
+end

--- a/config/breadcrumbs/page.rb
+++ b/config/breadcrumbs/page.rb
@@ -3,6 +3,6 @@ crumb :pages do
 end
 
 crumb :page do |page|
-  link page.identifier_name, page
+  link page.new_record? ? "New page" : page.identifier_name, page
   parent :pages
 end

--- a/config/breadcrumbs/person.rb
+++ b/config/breadcrumbs/person.rb
@@ -3,7 +3,7 @@ crumb :people do
 end
 
 crumb :person do |person|
-  link person.identifier_name, person
+  link person.new_record? ? "New person" : person.identifier_name, person
   parent :people
 end
 

--- a/config/breadcrumbs/relationship_type.rb
+++ b/config/breadcrumbs/relationship_type.rb
@@ -1,5 +1,6 @@
 crumb :relationship_types do
   link 'Relationship Types', relationship_types_path
+  parent :setup
 end
 
 crumb :relationship_type do |relationship_type|

--- a/config/breadcrumbs/relationship_type.rb
+++ b/config/breadcrumbs/relationship_type.rb
@@ -4,6 +4,6 @@ crumb :relationship_types do
 end
 
 crumb :relationship_type do |relationship_type|
-  link relationship_type.identifier_name, relationship_type
+  link relationship_type.new_record? ? "New relationship type" : relationship_type.identifier_name, relationship_type
   parent :relationship_types
 end

--- a/config/breadcrumbs/report.rb
+++ b/config/breadcrumbs/report.rb
@@ -3,7 +3,7 @@ crumb :reports do
 end
 
 crumb :report do |report|
-  link report.identifier_name, report
+  link report.new_record? ? "New report" : report.identifier_name, report
   parent :reports
 end
 

--- a/config/breadcrumbs/team.rb
+++ b/config/breadcrumbs/team.rb
@@ -3,6 +3,6 @@ crumb :teams do
 end
 
 crumb :team do |team|
-  link team.identifier_name, team
+  link team.new_record? ? "New team" : team.identifier_name, team
   parent :teams
 end

--- a/config/breadcrumbs/team_type.rb
+++ b/config/breadcrumbs/team_type.rb
@@ -1,5 +1,6 @@
 crumb :team_types do
   link "Team Types", team_types_path
+  parent :setup
 end
 
 crumb :team_type do |team_type|

--- a/config/breadcrumbs/team_type.rb
+++ b/config/breadcrumbs/team_type.rb
@@ -4,6 +4,6 @@ crumb :team_types do
 end
 
 crumb :team_type do |team_type|
-  link team_type.identifier_name, team_type
+  link team_type.new_record? ? "New team type" : team_type.identifier_name, team_type
   parent :team_types
 end

--- a/config/breadcrumbs/time_clock_period.rb
+++ b/config/breadcrumbs/time_clock_period.rb
@@ -3,6 +3,6 @@ crumb :time_clock_periods do
 end
 
 crumb :time_clock_period do |time_clock_period|
-  link time_clock_period.identifier_name, time_clock_period
+  link time_clock_period.new_record? ? "New time clock period" : time_clock_period.identifier_name, time_clock_period
   parent :time_clock_periods
 end

--- a/config/breadcrumbs/time_clock_punch.rb
+++ b/config/breadcrumbs/time_clock_punch.rb
@@ -3,6 +3,6 @@ crumb :time_clock_punches do
 end
 
 crumb :time_clock_punch do |time_clock_punch|
-  link time_clock_punch.identifier_name, time_clock_punch
+  link time_clock_punch.new_record? ? "New time clock punch" : time_clock_punch.identifier_name, time_clock_punch
   parent :time_clock_punches
 end

--- a/config/breadcrumbs/tokens.rb
+++ b/config/breadcrumbs/tokens.rb
@@ -3,6 +3,6 @@ crumb :tokens do
 end
 
 crumb :token do |token|
-  link token.identifier_name, token
+  link token.new_record? ? "New token" : token.identifier_name, token
   parent :tokens
 end

--- a/config/breadcrumbs/variable.rb
+++ b/config/breadcrumbs/variable.rb
@@ -3,6 +3,6 @@ crumb :variables do
 end
 
 crumb :variable do |variable|
-  link variable.identifier_name, variable
+  link variable.new_record? ? "New variable" : variable.identifier_name, variable
   parent :variables
 end

--- a/lib/generators/breadcrumb/templates/breadcrumb.rb.tt
+++ b/lib/generators/breadcrumb/templates/breadcrumb.rb.tt
@@ -3,6 +3,6 @@ crumb :<%= plural_table_name %> do
 end
 
 crumb :<%= singular_table_name %> do |<%= singular_table_name %>|
-  link <%= singular_table_name %>.identifier_name, <%= singular_table_name %>
+  link <%= singular_table_name %>.new_record? ? "New <%= singular_table_name.humanize.downcase %>" : <%= singular_table_name %>.identifier_name, <%= singular_table_name %>
   parent :<%= plural_table_name %>
 end

--- a/lib/generators/breadcrumb/templates/breadcrumb.rb.tt
+++ b/lib/generators/breadcrumb/templates/breadcrumb.rb.tt
@@ -1,5 +1,5 @@
 crumb :<%= plural_table_name %> do
-  link "<%= plural_table_name.capitalize %>", <%= index_helper(type: :path) %>
+  link "<%= plural_table_name.titlize %>", <%= index_helper(type: :path) %>
 end
 
 crumb :<%= singular_table_name %> do |<%= singular_table_name %>|

--- a/lib/templates/erb/scaffold/index.html.erb.tt
+++ b/lib/templates/erb/scaffold/index.html.erb.tt
@@ -3,7 +3,7 @@
 <%%= search_form_for @q, data: { "controller": "turbo_search", "turbo-frame": "results" } do |f| %>
 <div class="card">
   <div class="card-header">
-    <h1><%= human_name.pluralize %></h1>
+    <h1><%= human_name.pluralize.titleize %></h1>
   </div>
   <div class="card-body">
   </div>

--- a/lib/templates/erb/scaffold/index.html.erb.tt
+++ b/lib/templates/erb/scaffold/index.html.erb.tt
@@ -8,7 +8,7 @@
   <div class="card-body">
   </div>
   <div class="card-footer">
-    <%%= link_to "New <%= human_name.downcase %>", <%= new_helper(type: :path) %>, class: 'btn btn-success' %>
+    <%%= link_to "New <%= human_name.titleize %>", <%= new_helper(type: :path) %>, class: 'btn btn-success' %>
     <%%= f.submit 'Search', class: 'btn btn-primary', data: { action: "turbo_search#search" } %>
     <%%= link_to 'Clear Search', request.path, class: "btn btn-dark", data: { action: "turbo_search#clear" } %>
   </div>

--- a/lib/templates/erb/scaffold/new.html.erb.tt
+++ b/lib/templates/erb/scaffold/new.html.erb.tt
@@ -1,4 +1,4 @@
-<%% breadcrumb :new, "<%= singular_table_name.humanize.downcase %>" %>
+<%% breadcrumb @<%= singular_table_name %> %>
 
 <%%= simple_form_for(@<%= singular_table_name %>) do |f| %>
   <div class="card">

--- a/lib/templates/erb/scaffold/new.html.erb.tt
+++ b/lib/templates/erb/scaffold/new.html.erb.tt
@@ -1,9 +1,9 @@
-<%% breadcrumb :new, "<%= singular_table_name.downcase %>" %>
+<%% breadcrumb :new, "<%= singular_table_name.humanize.downcase %>" %>
 
 <%%= simple_form_for(@<%= singular_table_name %>) do |f| %>
   <div class="card">
     <div class="card-header">
-      <h1>New <%= human_name.downcase %></h1>
+      <h1>New <%= human_name.humanize.downcase %></h1>
     </div>
     <div class="card-body">
       <%%= render "form", f: f %>


### PR DESCRIPTION
There are some slight issues with generators of breadcrumbs...at least that what this was intended to fix. There's a lot more styling inconsistencies that I've noticed and it's a bit annoying. 

Notable changes:
- use `.titleize` for parent paths breadcrumb. Multiple word long models now render correctly `Ledger_tag` => `Ledger Tag`.
- use `.humanize` before downcasing, same reason as above.
- some other scaffolding have different casing than other pages, tried to match with the format of most models.
- `#new` breadcrumbs link to the correct parent.